### PR TITLE
Fix bug - Exception will be thrown when InvoicePayment is created

### DIFF
--- a/Harvest.Api/Models/IdNameModel.cs
+++ b/Harvest.Api/Models/IdNameModel.cs
@@ -11,4 +11,11 @@ namespace Harvest.Api
         public long Id { get; set; }
         public string Name { get; set; }
     }
+
+    [DebuggerDisplay("{Name}")]
+    public class NullableIdNameModel
+    {
+        public long? Id { get; set; }
+        public string Name { get; set; }
+    }
 }

--- a/Harvest.Api/Models/InvoicePayment.cs
+++ b/Harvest.Api/Models/InvoicePayment.cs
@@ -13,7 +13,7 @@ namespace Harvest.Api
         public string RecordedByEmail { get; set; } // The email of the person who recorded the payment.
         public string Notes { get; set; } // Any notes associated with the payment.
         public string TransactionId { get; set; } // Either the card authorization or PayPal transaction ID.
-        public IdNameModel PaymentGateway { get; set; } // The payment gateway id and name used to process the payment.
+        public NullableIdNameModel PaymentGateway { get; set; } // The payment gateway id and name used to process the payment.
     }
 
     public class InvoicePaymentsReponse : PagedList


### PR DESCRIPTION
When InvoicePayment is created, the payment_gateway.id in the response is null.
An exception will be thrown when assigning the null value to the field 'id' of the return object, which type is 'long'.
* The InvoicePayment has been created successfully in Harvest at that time

Solution:
Change the type of PaymentGateway to the nullable IdNameModel