### PR TITLE
Invoice creator can be null in some case,  Add Project Budget Report, Fix the parameter name

### DIFF
--- a/Harvest.Api/Harvest.Api.csproj
+++ b/Harvest.Api/Harvest.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;netstandard2.0;net45;net46;</TargetFrameworks>
+    <TargetFrameworks>net5;netstandard2.0;net45;net46;net48;</TargetFrameworks>
     <Version>0.0.31</Version>
     <AssemblyVersion>0.0.0.31</AssemblyVersion>
     <FileVersion>0.0.0.31</FileVersion>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.*" />
     <PackageReference Include="System.Net.Http" Version="4.3.*" />
   </ItemGroup>
 

--- a/Harvest.Api/HarvestClient.cs
+++ b/Harvest.Api/HarvestClient.cs
@@ -606,10 +606,10 @@ namespace Harvest.Api
                 .SendAsync<UserRatesResponse>(_httpClient, cancellationToken);
         }
 
-        public async Task<UserRate> GetUserBillableRateAsync(long userId, long costRateId, long? accountId = null, CancellationToken cancellationToken = default)
+        public async Task<UserRate> GetUserBillableRateAsync(long userId, long billableRateId, long? accountId = null, CancellationToken cancellationToken = default)
         {
             await RefreshTokenIsNeeded();
-            return await SimpleRequestBuilder($"{harvestApiUrl}/users/{userId}/billable_rates/{costRateId}", accountId)
+            return await SimpleRequestBuilder($"{harvestApiUrl}/users/{userId}/billable_rates/{billableRateId}", accountId)
                 .SendAsync<UserRate>(_httpClient, cancellationToken);
         }
 

--- a/Harvest.Api/HarvestClient.cs
+++ b/Harvest.Api/HarvestClient.cs
@@ -1116,6 +1116,17 @@ namespace Harvest.Api
                 .Query("per_page", perPage)
                 .SendAsync<ExpenseReportResponse>(_httpClient, cancellationToken);
         }
+		
+		public async Task<ProjectBudgetReportResponse> GetProjectBudgetReportAsync(bool? isActive = null, int? page = null, int? perPage = null,
+            long? accountId = null, CancellationToken cancellationToken = default)
+        {
+            await RefreshTokenIsNeeded();
+            return await SimpleRequestBuilder($"{harvestApiUrl}/reports/project_budget", accountId)
+                .Query("page", page)
+                .Query("per_page", perPage)
+                .Query("is_active", isActive)
+                .SendAsync<ProjectBudgetReportResponse>(_httpClient, cancellationToken);
+        }
 
         public async Task<UninvoicedReportResponse> GetUninvoicedReportAsync(DateTime fromDate, DateTime toDate, int? page = null, int? perPage = null,
             long? accountId = null, CancellationToken cancellationToken = default)

--- a/Harvest.Api/HarvestClient.cs
+++ b/Harvest.Api/HarvestClient.cs
@@ -623,6 +623,23 @@ namespace Harvest.Api
                 .SendAsync<UserRate>(_httpClient, cancellationToken);
         }
 
+        public async Task<TeammatesResponse> GetUserTeammatesAsync(long userId, int? page = null, int? perPage = null, long? accountId = null, CancellationToken cancellationToken = default)
+        {
+            await RefreshTokenIsNeeded();
+            return await SimpleRequestBuilder($"{harvestApiUrl}/users/{userId}/teammates", accountId)
+                .QueryPageSince(page: page, perPage: perPage)
+                .SendAsync<TeammatesResponse>(_httpClient, cancellationToken);
+        }
+
+        public async Task<Teammate[]> UpdateUserTeammatesAsync(long userId, long[] teammateIds,
+            long? accountId = null, CancellationToken cancellationToken = default)
+        {
+            await RefreshTokenIsNeeded();
+            return await SimpleRequestBuilder($"{harvestApiUrl}/users/{userId}/teammates", accountId, HttpMethod.Post)
+                .Body("teammate_ids", teammateIds)
+                .SendAsync<Teammate[]>(_httpClient, cancellationToken);
+        }
+		
         public async Task<RolesResponse> GetRolesAsync(DateTime? updatedSince = null, int? page = null, int? perPage = null,
             long? accountId = null, CancellationToken cancellationToken = default)
         {

--- a/Harvest.Api/Models/Invoice.cs
+++ b/Harvest.Api/Models/Invoice.cs
@@ -10,7 +10,7 @@ namespace Harvest.Api
         public LineItem[] LineItems { get; set; } // Array of invoice line items.
         public IdNameModel Estimate { get; set; } // An object containing the associated estimate’s id.
         public IdNameModel Retainer { get; set; } // An object containing the associated retainer’s id.
-        public IdNameModel Creator { get; set; } // An object containing the id and name of the person that created the invoice.
+        public NullableIdNameModel Creator { get; set; } // An object containing the id and name of the person that created the invoice.
         public string ClientKey { get; set; } // Used to build a URL to the public web invoice for your client:https://{ACCOUNT_SUBDOMAIN}.harvestapp.com/client/invoices/abc123456
         public string Number { get; set; } // If no value is set, the number will be automatically generated.
         public string PurchaseOrder { get; set; } // The purchase order number.

--- a/Harvest.Api/Models/ProjectBudgetReport.cs
+++ b/Harvest.Api/Models/ProjectBudgetReport.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Harvest.Api
+{
+    public class ProjectBudgetReport
+    {
+        public long ClientId { get; set; }
+        public string ClientName { get; set; }
+        public long ProjectId { get; set; }
+        public string ProjectName { get; set; }
+        public bool BudgetIsMonthly { get; set; }
+        public string BudgetBy { get; set; }
+        public bool IsActive { get; set; }
+        public decimal? Budget { get; set; }
+        public decimal? BudgetSpent { get; set; }
+        public decimal? BudgetRemaining { get; set; }
+    }
+
+    public class ProjectBudgetReportResponse : PagedList
+    {
+        public ProjectBudgetReport[] Results { get; set; }
+    }
+}
+

--- a/Harvest.Api/Models/Teammate.cs
+++ b/Harvest.Api/Models/Teammate.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Harvest.Api
+{
+    [DebuggerDisplay("{FirstName} {LastName}")]
+    public class Teammate
+    {
+        public long Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+    }
+
+    public class TeammatesResponse : PagedList
+    {
+        public Teammate[] Teammates { get; set; }
+    }
+}


### PR DESCRIPTION
1. Invoice creator can be null in some case
When retrieving invoices from Harvest, some have null creators so cannot be deserialized correctly.
Not sure how they were generated. May be related to deleted users.
Change the Creator of Invoice to NullableIdNameModel to workaround it.

2. Add Project Budget Report

3. Fix the parameter name of GetUserBillableRateAsync()